### PR TITLE
Add assertNoFlashMessage method

### DIFF
--- a/src/Test/Controller/AdminWebTestCase.php
+++ b/src/Test/Controller/AdminWebTestCase.php
@@ -94,6 +94,19 @@ abstract class AdminWebTestCase extends WebTestCase
         $this->assertFlashMessage('danger', $expectedMessage, ...$expectedMessages);
     }
 
+    protected function assertNoFlashMessage(): void
+    {
+        $crawler = $this->getClient()->getCrawler();
+
+        $flashMessages = $crawler->filter('#flash-messages [class*="alert-"]');
+
+        self::assertCount(
+            0,
+            $flashMessages,
+            Str\format('Expected no flash messages, found %d.', $flashMessages->count())
+        );
+    }
+
     private function assertFlashMessage(string $type, string ...$expectedMessages): void
     {
         $crawler        = $this->getClient()->getCrawler();


### PR DESCRIPTION
This pull request

* Adds a method (`assertNoFlashMessage`) to the `AdminWebTestCase` to assert that there are no flash messages present on the loaded page. It will detect all types of flash messages on the page and assert that none exist.  

