### PR TITLE
Use target entity instance as a field value of `EntityField` in *-to-one relation

### DIFF
--- a/src/Field/Configurator/EntityConfigurator.php
+++ b/src/Field/Configurator/EntityConfigurator.php
@@ -184,8 +184,10 @@ final class EntityConfigurator implements FieldConfiguratorInterface
                 : $this->entityFactory->create($entityMetadata->targetEntityFqcn(), $entityMetadata->targetEntityId());
         }
 
+        $targetEntityInstance = Type\nullable(Type\instance_of($entityMetadata->targetEntityFqcn()))->coerce($targetEntityDto->getInstance());
+
         $field->setFormTypeOptionIfNotSet('class', $targetEntityDto->getFqcn());
-        $field->setFormTypeOptionIfNotSet('data', $targetEntityDto->getInstance());
+        $field->setFormTypeOptionIfNotSet('data', $targetEntityInstance);
         $field->setFormTypeOptionIfNotSet('data_class', null);
 
         if ($field->getCustomOption(EntityField::OPTION_LINK_TO_ENTITY) === true) {
@@ -198,9 +200,10 @@ final class EntityConfigurator implements FieldConfiguratorInterface
             );
         }
 
+        $field->setValue($targetEntityInstance);
         $field->setFormattedValue(
             $this->formatAsString(
-                Type\nullable(Type\instance_of($entityMetadata->targetEntityFqcn()))->coerce($targetEntityDto->getInstance()),
+                $targetEntityInstance,
                 $entityMetadata,
                 $field,
             ),


### PR DESCRIPTION
This is especially useful when using `setEntityDtoFactoryCallable` option, because it allows to access the actual entity fetched using the callable in twig template instead of the value passed to the callable.

The BC break is minor, because there is no call to `field.value` in `entity.html.twig`, only `field.formattedValue` is used. And even for consumers of the library that use their own templates it should still be better to be able to receive an actual target entity as a value instead of just an ID.