### PR TITLE
Fix validation errors response expectation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "php": "~8.1.0 || ~8.2.0",
     "ext-dom": "*",
     "azjezz/psl": "^2.3.1",
-    "easycorp/easyadmin-bundle": "~4.5.1",
+    "easycorp/easyadmin-bundle": "~v4.6.5",
     "symfony/asset": "^5.4 || ^6.2",
     "symfony/cache": "^5.4 || ^6.2",
     "symfony/config": "^5.4 || ^6.2",
@@ -53,9 +53,6 @@
     "psalm/plugin-symfony": "^5.0.1",
     "speicher210/functional-test-bundle": "^2.x-dev",
     "vimeo/psalm": "^5.6"
-  },
-  "conflict": {
-    "easycorp/easyadmin-bundle": ">=4.5.2"
   },
   "suggest": {
     "speicher210/functional-test-bundle": "For testing support."

--- a/src/Test/Controller/EditActionTestCase.php
+++ b/src/Test/Controller/EditActionTestCase.php
@@ -127,7 +127,7 @@ abstract class EditActionTestCase extends AdminControllerWebTestCase
     ): void {
         $crawler = $this->submitFormRequest($data, $files, $queryParameters);
 
-        self::assertResponseStatusCode($this->getClient()->getResponse(), Response::HTTP_OK);
+        self::assertResponseStatusCode($this->getClient()->getResponse(), Response::HTTP_UNPROCESSABLE_ENTITY);
 
         $form = $this->findForm($crawler);
 

--- a/src/Test/Controller/NewActionTestCase.php
+++ b/src/Test/Controller/NewActionTestCase.php
@@ -94,7 +94,7 @@ abstract class NewActionTestCase extends AdminControllerWebTestCase
     ): void {
         $crawler = $this->submitFormRequest($data, $files, $queryParameters);
 
-        self::assertResponseStatusCode($this->getClient()->getResponse(), Response::HTTP_OK);
+        self::assertResponseStatusCode($this->getClient()->getResponse(), Response::HTTP_UNPROCESSABLE_ENTITY);
 
         $form = $this->findForm($crawler);
 


### PR DESCRIPTION
Easy admin, in their most recent update: 4.6.5 -> 4.6.6 introduced a bug fix in which responses with form validation errors have a 422 code rather than a 200 code. 

https://github.com/EasyCorp/EasyAdminBundle/commit/ef7fed4da6293531e98436c20e930e881c9a443f

This means that the expected response codes here: 
`src/Test/Controller/EditActionTestCase.php:130`
and here
`src/Test/Controller/NewActionTestCase.php:97`

need to be updated. 