### PR TITLE
Change signature of entity field query builder callable option 

### DIFF
--- a/src/Field/Configurator/EntityConfigurator.php
+++ b/src/Field/Configurator/EntityConfigurator.php
@@ -144,7 +144,7 @@ final class EntityConfigurator implements FieldConfiguratorInterface
 
             $field->setFormTypeOption('attr.data-ea-autocomplete-endpoint-url', $autocompleteEndpointUrl);
         } else {
-            $field->setFormTypeOptionIfNotSet('query_builder', static function (EntityRepository $repository) use ($field, $context): QueryBuilder {
+            $field->setFormTypeOptionIfNotSet('query_builder', static function (EntityRepository $repository) use ($field): QueryBuilder {
                 // it would then be identical to the one used in autocomplete action, but it is a bit complex getting it in here
                 $queryBuilder         = $repository->createQueryBuilder('entity');
                 $queryBuilderCallable = $field->getCustomOption(EntityField::OPTION_QUERY_BUILDER_CALLABLE);
@@ -153,7 +153,7 @@ final class EntityConfigurator implements FieldConfiguratorInterface
                         is_callable($queryBuilderCallable),
                         Str\format('Query builder callable option is not null or callable.'),
                     );
-                    $queryBuilderCallable($queryBuilder, $context);
+                    $queryBuilderCallable($queryBuilder);
                 }
 
                 return $queryBuilder;

--- a/src/Field/EntityField.php
+++ b/src/Field/EntityField.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Protung\EasyAdminPlusBundle\Field;
 
 use Doctrine\ORM\QueryBuilder;
-use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
@@ -170,7 +169,7 @@ final class EntityField implements FieldInterface
     }
 
     /**
-     * @param (callable(QueryBuilder, AdminContext): void) $callable
+     * @param (callable(QueryBuilder): void) $callable
      */
     public function setQueryBuilderCallable(callable $callable): self
     {


### PR DESCRIPTION
Changes signature of  `EntityField` `OPTION_QUERY_BUILDER_CALLABLE` option to be in sync with EasyAdmin `AssociationField` option. This way it is possible to switch between autocomplete and not autocomplete for `EntityField` without the need to update the query builder callable.

The signature had the argument of AdminContext removed but it should not be a problem, because when configuring the callable for the field in the controller admin context can be retrieved using `$this->currentAdminContext()` method.

